### PR TITLE
Return types of `step()` is aligned

### DIFF
--- a/modelicagym/environment/modelica_base_env.py
+++ b/modelicagym/environment/modelica_base_env.py
@@ -238,7 +238,7 @@ class ModelicaBaseEnv(gym.Env):
         :return: Values of model outputs as tuple in order specified in `model_outputs` attribute
         """
         model_outputs = self.model_output_names
-        return tuple([result.final(k) for k in model_outputs])
+        return np.array([result.final(k) for k in model_outputs])
 
     def _set_init_parameter(self):
         """

--- a/modelicagym/environment/modelica_base_env.py
+++ b/modelicagym/environment/modelica_base_env.py
@@ -135,7 +135,7 @@ class ModelicaBaseEnv(gym.Env):
                 """You are calling 'step()' even though this environment has already returned done = True.
                 You should always call 'reset()' once you receive 'done = True' -- any further steps are
                 undefined behavior.""")
-            return np.array(self.state), self.negative_reward, self.done, {}
+            return self.state, self.negative_reward, self.done, {}
 
         # check if action is a list. If not - create list of length 1
         try:


### PR DESCRIPTION
Aligned return type of different branches of the `step()` function, i.e. both successful and failed step return `np.array` now.
To this end return type was changed from `tuple` to `numpy.array` for the successful branch